### PR TITLE
Changed documentation for 'not trigger'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For more commands take a look at the python script aidatlu.py.
 All configurations are done by the use of a yaml file (tlu_configuration.yaml).
 
 # Tests
-With pytest (https://docs.pytest.org/en/stable/) the AIDA TLU control program can be tested.
+With [pytest](https://docs.pytest.org/en/stable/) the AIDA TLU control program can be tested.
 There is also an implemented AIDA-TLU mock, to allow tests and software development without hardware,
 which also allows software development and testing without a working IPbus installation.
 The mock is used as a default.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For more commands take a look at the python script aidatlu.py.
 All configurations are done by the use of a yaml file (tlu_configuration.yaml).
 
 # Tests
-With pytest (https://docs.pytest.org/en/7.4.x/) the AIDA TLU control program can be tested.
+With pytest (https://docs.pytest.org/en/stable/) the AIDA TLU control program can be tested.
 There is also an implemented AIDA-TLU mock, to allow tests and software development without hardware,
 which also allows software development and testing without a working IPbus installation.
 The mock is used as a default.

--- a/aidatlu/README.md
+++ b/aidatlu/README.md
@@ -24,9 +24,9 @@ The threshold for each trigger input can be tuned individually between [-1.3; 1.
 Another setting controls the trigger input logic.
 Each trigger input can have one of three settings. The input can act as 'active', 'veto' or 'do not care'.
 Between each trigger input, there is also the possibility to set 'AND' or 'OR'.
-A desired trigger configuration is set with the use of the [Python bitwise operators](https://wiki.python.org/moin/BitwiseOperators).
+A desired trigger configuration is set with the use of the Python boolean operators.
 These operators are used in conjunction with the input channels CH1-CH6 and interpreted as a literal logic expression.
-For example "(CH1 & ~CH2) & (CH3 | CH4 | CH5 | CH6)" produces a valid trigger, when CH1 and not CH2 triggers and when one of CH3, CH4, CH5 or CH6 triggers.
+For example "(CH1 & (not CH2)) & (CH3 | CH4 | CH5 | CH6)" produces a valid trigger, when CH1 and not CH2 triggers and when one of CH3, CH4, CH5 or CH6 triggers.
 An input channel that is not explicitly set to 'veto' or 'enabled' is automatically set to 'do not care'.
 
 TLU can trigger on a rising or falling edge. Trigger polarity is set using a string or boolean,

--- a/aidatlu/main/config_parser.py
+++ b/aidatlu/main/config_parser.py
@@ -58,12 +58,7 @@ class TLUConfigure:
             ),
             (
                 "trigger_polarity",
-                "%s"
-                % (
-                    "falling"
-                    if self.conf["trigger_inputs"]["trigger_polarity"]["polarity"] == 1
-                    else "rising"
-                ),
+                "%s" % (self.conf["trigger_inputs"]["trigger_polarity"]["polarity"]),
             ),
             (
                 "enable_clock_lemo_output",

--- a/aidatlu/test/fixtures/tlu_test_configuration.yaml
+++ b/aidatlu/test/fixtures/tlu_test_configuration.yaml
@@ -34,7 +34,7 @@ trigger_inputs:
 
   # Trigger Logic configuration accept a python expression for the trigger inputs.
   # The logic is set by using the variables for the input channels 'CH1', 'CH2', 'CH3', 'CH4', 'CH5' and 'CH6'
-  # and the Python bitwise operators AND: '&', OR: '|', NOT: '~' and so on. Dont forget to use brackets...
+  # and the Python bitwise operators AND: '&', OR: '|', NOT: 'not' and so on. Dont forget to use brackets...
   trigger_inputs_logic: (CH1 & CH2) | CH3
 
   # TLU can trigger on a rising or falling edge. Trigger polarity is set using a string or boolean,

--- a/aidatlu/tlu_configuration.yaml
+++ b/aidatlu/tlu_configuration.yaml
@@ -26,7 +26,7 @@ trigger_inputs:
 
   # Trigger Logic configuration accept a python expression for the trigger inputs.
   # The logic is set by using the variables for the input channels 'CH1', 'CH2', 'CH3', 'CH4', 'CH5' and 'CH6'
-  # and the Python bitwise operators AND: '&', OR: '|', NOT: '~' and so on. Dont forget to use brackets...
+  # and the Python bitwise operators AND: '&', OR: '|', NOT: 'not' and so on. Dont forget to use brackets...
   trigger_inputs_logic: CH2 & CH4
 
   # TLU can trigger on a rising or falling edge. Trigger polarity is set using a string or boolean,

--- a/docs/source/Documentation.rst
+++ b/docs/source/Documentation.rst
@@ -307,7 +307,7 @@ Another command reliable stops all instances of the running online monitor:
 
 Tests
 ------
-With pytest (https://docs.pytest.org/en/7.4.x/) the AIDA TLU control program can be tested.
+With pytest (https://docs.pytest.org/en/stable/) the AIDA TLU control program can be tested.
 In the test directory different testing scripts can be found.
 The test setup helps to find bugs when further developing the TLU program and also to check for depreciated functions.
 The command:


### PR DESCRIPTION
Switched the comments about not trigger. The operator '~' is the bit wise complement. Where the explicit 'not' gives the correct trigger configurations for 'not trigger'.

And I updated the [pytest](https://docs.pytest.org/en/stable/) link.