### PR TITLE
Trigger logic refactoring

### DIFF
--- a/aidatlu/main/config_parser.py
+++ b/aidatlu/main/config_parser.py
@@ -240,11 +240,11 @@ class TLUConfigure:
 
         self.log.info("Trigger Configuration: %s" % (trigger_configuration))
 
-        # Sets the Trigger Leds to green if the Input is enabled and to red if the input is set to VETO.
-        # TODO this breaks when there are multiple enabled and veto statements.
         if trigger_configuration is not None:
+            # Sets the Trigger Leds to green if the Input is enabled and to red if the input is set to VETO.
+            # TODO this breaks when there are multiple enabled and veto statements for the same trigger input.
             for trigger_led in range(6):
-                if "~CH%i" % (trigger_led + 1) in trigger_configuration:
+                if "not CH%i" % (trigger_led + 1) in trigger_configuration:
                     self.tlu.io_controller.switch_led(trigger_led + 6, "r")
                 elif "CH%i" % (trigger_led + 1) in trigger_configuration:
                     self.tlu.io_controller.switch_led(trigger_led + 6, "g")

--- a/aidatlu/test/fixtures/tlu_test_configuration.yaml
+++ b/aidatlu/test/fixtures/tlu_test_configuration.yaml
@@ -35,7 +35,7 @@ trigger_inputs:
   # Trigger Logic configuration accept a python expression for the trigger inputs.
   # The logic is set by using the variables for the input channels 'CH1', 'CH2', 'CH3', 'CH4', 'CH5' and 'CH6'
   # and the Python bitwise operators AND: '&', OR: '|', NOT: 'not' and so on. Dont forget to use brackets...
-  trigger_inputs_logic: (CH1 & CH2) | CH3
+  trigger_inputs_logic: '(CH1 & (not CH2) & (not CH3) & (not CH4) & (CH5) & (not CH6))'
 
   # TLU can trigger on a rising or falling edge. Trigger polarity is set using a string or boolean,
   # 'rising' corresponds to false and 'falling' to true

--- a/aidatlu/test/test_configuration.py
+++ b/aidatlu/test/test_configuration.py
@@ -130,7 +130,6 @@ def test_trigger_input_configuration():
         config_path=CONFIG_FILE,
     )
     config_parser.conf_trigger_inputs()
-
     if MOCK:
         # Write array concatenates array bitwise, this is not implemented in the mock
         mem_addr = 0x18 + (0 & 0x7)
@@ -148,8 +147,8 @@ def test_trigger_input_configuration():
         assert TLU.i2c.read(TLU.i2c.modules["dac_1"], mem_addr) == 0x31
         assert TLU.i2c.read(TLU.i2c.modules["dac_2"], mem_addr) == 0x31
 
-    assert TLU.i2c.read_register("triggerLogic.TriggerPattern_lowR") == 0xF8F8F8F8
-    assert TLU.i2c.read_register("triggerLogic.TriggerPattern_highR") == 0xF8F8F8F8
+    assert TLU.i2c.read_register("triggerLogic.TriggerPattern_lowR") == 0x20000
+    assert TLU.i2c.read_register("triggerLogic.TriggerPattern_highR") == 0x0
 
 
 def test_conf_auxillary():


### PR DESCRIPTION
Small refactoring for the trigger input logic. This allows easier access for the conversion functions
and helps testing and debugging.

Additionally, I changed the test configuration for the trigger logic configuration  so `mask_high` and `mask_low` are different, which also improves testing.
The specific configuration is the same as an example configuration given in the [TLU manual](https://ohwr.org/project/fmc-mtlu/blob/master/Documentation/Main_TLU.pdf).