### PR TITLE
ENH: Improve configuration procedure and more conf file formats

### DIFF
--- a/aidatlu/aidatlu_run.py
+++ b/aidatlu/aidatlu_run.py
@@ -1,5 +1,6 @@
 import uhal
 from main.tlu import AidaTLU
+from main.config_parser import yaml_parser
 
 
 class AIDATLU:
@@ -32,7 +33,8 @@ class AIDATLU:
         self.aidatlu.configure()
 
     def init(self):
-        self.aidatlu = AidaTLU(hw, self.config_file, self.clock_file)
+        conf_dict = yaml_parser(self.config_file)
+        self.aidatlu = AidaTLU(hw, conf_dict, self.clock_file)
 
     def help(self):
         print("tlu.configure()")

--- a/aidatlu/main/config_parser.py
+++ b/aidatlu/main/config_parser.py
@@ -1,4 +1,5 @@
 import yaml
+import tomllib
 
 from aidatlu import logger
 
@@ -289,5 +290,73 @@ def yaml_parser(conf_file_path) -> list:
     return conf
 
 
-def toml_parser():
-    pass
+def toml_parser(conf_file_path):
+    """Parses a toml configuration file to a configuration dictionary.
+
+    Returns:
+        conf: configuration dictionary
+    """
+    with open(conf_file_path, "rb") as file:
+        toml_conf = tomllib.load(file)
+    conf = {
+        "internal_trigger_rate": toml_conf["internal_trigger_rate"],
+        "DUT_1": (
+            False
+            if toml_conf["dut_interfaces"][0] in ["False", "None", "off"]
+            else toml_conf["dut_interfaces"][0]
+        ),
+        "DUT_2": (
+            False
+            if toml_conf["dut_interfaces"][1] in ["False", "None", "off"]
+            else toml_conf["dut_interfaces"][1]
+        ),
+        "DUT_3": (
+            False
+            if toml_conf["dut_interfaces"][2] in ["False", "None", "off"]
+            else toml_conf["dut_interfaces"][2]
+        ),
+        "DUT_4": (
+            False
+            if toml_conf["dut_interfaces"][3] in ["False", "None", "off"]
+            else toml_conf["dut_interfaces"][3]
+        ),
+        "threshold_1": toml_conf["trigger_threshold"][0],
+        "threshold_2": toml_conf["trigger_threshold"][1],
+        "threshold_3": toml_conf["trigger_threshold"][2],
+        "threshold_4": toml_conf["trigger_threshold"][3],
+        "threshold_5": toml_conf["trigger_threshold"][4],
+        "threshold_6": toml_conf["trigger_threshold"][5],
+        "trigger_inputs_logic": toml_conf["trigger_inputs_logic"],
+        "trigger_signal_shape_stretch": toml_conf["trigger_signal_stretch"],
+        "trigger_signal_shape_delay": toml_conf["trigger_signal_delay"],
+        "trigger_polarity": toml_conf["trigger_polarity"],
+        "enable_clock_lemo_output": (
+            False
+            if toml_conf["enable_clock_lemo_output"] in ["False", "None"]
+            else True
+        ),
+        "pmt_control_1": toml_conf["pmt_power"][0],
+        "pmt_control_2": toml_conf["pmt_power"][1],
+        "pmt_control_3": toml_conf["pmt_power"][2],
+        "pmt_control_4": toml_conf["pmt_power"][3],
+        "save_data": (
+            False if toml_conf["save_data"] in ["False", "None", "off"] else True
+        ),
+        "output_data_path": toml_conf["output_data_path"],
+        "zmq_connection": (
+            False
+            if toml_conf["zmq_connection"] in ["False", "None", "off"]
+            else toml_conf["zmq_connection"]
+        ),
+        "max_trigger_number": (
+            None
+            if toml_conf["max_trigger_number"] in ["False", "None", "off"]
+            else toml_conf["max_trigger_number"]
+        ),
+        "timeout": (
+            None
+            if toml_conf["timeout"] in ["False", "None", "off"]
+            else toml_conf["timeout"]
+        ),
+    }
+    return conf

--- a/aidatlu/main/config_parser.py
+++ b/aidatlu/main/config_parser.py
@@ -30,7 +30,7 @@ class TLUConfigure:
         conf = [
             (
                 "internal_trigger_rate",
-                self.conf["internal_trigger"]["internal_trigger_rate"],
+                self.conf["internal_trigger_rate"],
             ),
             ("DUT_1", self.conf["dut_module"]["dut_1"]["mode"]),
             ("DUT_2", self.conf["dut_module"]["dut_2"]["mode"]),
@@ -58,11 +58,11 @@ class TLUConfigure:
             ),
             (
                 "trigger_polarity",
-                "%s" % (self.conf["trigger_inputs"]["trigger_polarity"]["polarity"]),
+                "%s" % (self.conf["trigger_inputs"]["trigger_polarity"]),
             ),
             (
                 "enable_clock_lemo_output",
-                self.conf["clock_lemo"]["enable_clock_lemo_output"],
+                self.conf["enable_clock_lemo_output"],
             ),
             ("pmt_control_1", self.conf["pmt_control"]["pmt_1"]),
             ("pmt_control_2", self.conf["pmt_control"]["pmt_2"]),
@@ -119,9 +119,7 @@ class TLUConfigure:
 
     def conf_auxillary(self):
         """Configures PMT power outputs and clock LEMO I/O"""
-        self.tlu.io_controller.clock_lemo_output(
-            self.conf["clock_lemo"]["enable_clock_lemo_output"]
-        )
+        self.tlu.io_controller.clock_lemo_output(self.conf["enable_clock_lemo_output"])
         [
             self.tlu.dac_controller.set_voltage(
                 i + 1, self.conf["pmt_control"]["pmt_%s" % (i + 1)]
@@ -192,13 +190,13 @@ class TLUConfigure:
     def conf_trigger_logic(self) -> None:
         """Configures the trigger logic. So the trigger polarity and the trigger pulse length and stretch."""
 
-        if self.conf["trigger_inputs"]["trigger_polarity"]["polarity"] in [
+        if self.conf["trigger_inputs"]["trigger_polarity"] in [
             0,
             "0",
             "rising",
         ]:
             self.tlu.trigger_logic.set_trigger_polarity(0)
-        elif self.conf["trigger_inputs"]["trigger_polarity"]["polarity"] in [
+        elif self.conf["trigger_inputs"]["trigger_polarity"] in [
             1,
             "1",
             "falling",
@@ -221,7 +219,7 @@ class TLUConfigure:
         )
 
         self.tlu.trigger_logic.set_internal_trigger_frequency(
-            self.conf["internal_trigger"]["internal_trigger_rate"]
+            self.conf["internal_trigger_rate"]
         )
 
     def conf_trigger_inputs(self) -> None:

--- a/aidatlu/main/tlu.py
+++ b/aidatlu/main/tlu.py
@@ -14,12 +14,12 @@ from aidatlu.hardware.dut_controller import DUTLogic
 from aidatlu.hardware.i2c import I2CCore
 from aidatlu.hardware.ioexpander_controller import IOControl
 from aidatlu.hardware.trigger_controller import TriggerLogic
-from aidatlu.main.config_parser import TLUConfigure
+from aidatlu.main.config_parser import Configure, yaml_parser
 from aidatlu.main.data_parser import interpret_data
 
 
 class AidaTLU:
-    def __init__(self, hw, config_path, clock_config_path, i2c=I2CCore) -> None:
+    def __init__(self, hw, config_dict, clock_config_path, i2c=I2CCore) -> None:
         self.log = logger.setup_main_logger(__class__.__name__)
 
         self.i2c = i2c(hw)
@@ -39,7 +39,7 @@ class AidaTLU:
         self.dut_logic = DUTLogic(self.i2c)
 
         self.reset_configuration()
-        self.config_parser = TLUConfigure(self, config_path)
+        self.config_parser = Configure(self, config_dict)
 
         self.log.success("TLU initialized")
 
@@ -471,6 +471,7 @@ if __name__ == "__main__":
     clock_path = "../misc/aida_tlu_clk_config.txt"
     config_path = "../tlu_configuration.yaml"
 
+    conf_dict = yaml_parser(config_path)
     tlu = AidaTLU(hw, config_path, clock_path)
 
     tlu.configure()

--- a/aidatlu/test/fixtures/tlu_test_configuration.toml
+++ b/aidatlu/test/fixtures/tlu_test_configuration.toml
@@ -1,0 +1,19 @@
+internal_trigger_rate = 100000
+dut_interfaces = ['aida', 'eudet', 'aidatrig', 'off']
+
+trigger_threshold = [-0.1, -0.2, -0.3, -0.4, -0.5, -0.6]
+trigger_inputs_logic = '(CH1 & (not CH2) & (not CH3) & (not CH4) & (CH5) & (not CH6))'
+trigger_polarity = 'falling'
+trigger_signal_stretch = [2, 2, 3, 2, 2, 2]
+trigger_signal_delay = [0, 1, 0, 0, 3, 0]
+
+enable_clock_lemo_output = 'True'
+pmt_power = [0.8, 0.8, 0, -0.2]
+save_data = 'True'
+output_data_path = 'aidatlu/test/fixtures/test_output_data/'
+zmq_connection = 'False'
+
+# Optional stop conditions can also be added to the configuration.
+# These can be by timeout in seconds or a maximum output trigger number.
+max_trigger_number = 'None'
+timeout = 5

--- a/aidatlu/test/fixtures/tlu_test_configuration.yaml
+++ b/aidatlu/test/fixtures/tlu_test_configuration.yaml
@@ -65,8 +65,6 @@ output_data_path: 'aidatlu/test/fixtures/test_output_data/'
 # zmq connection for status messages, leave it blank or set to off if not needed
 zmq_connection: off #"tcp://:7500"
 
-# Optional stop conditions can also be added to the configuration.
-# These can be by timeout in seconds or a maximum output trigger number.
-# If needed just uncomment the required stop condition in the example below:
-# max_trigger_number: 1000000
+# Optional stop conditions these can be by timeout in seconds or a maximum output trigger number.
+max_trigger_number: None
 timeout: 5

--- a/aidatlu/test/fixtures/tlu_test_configuration.yaml
+++ b/aidatlu/test/fixtures/tlu_test_configuration.yaml
@@ -7,8 +7,7 @@
 
 
 # Generate TLU internal trigger with given rate in Hz
-internal_trigger:
-  internal_trigger_rate: 100000
+internal_trigger_rate: 100000
 
 # Set operating mode of the DUT, supported are three operating modes 'aida', 'aidatrig' and 'eudet'
 # Set unused DUT interfaces to off, false or None
@@ -39,8 +38,7 @@ trigger_inputs:
 
   # TLU can trigger on a rising or falling edge. Trigger polarity is set using a string or boolean,
   # 'rising' corresponds to false and 'falling' to true
-  trigger_polarity:
-    polarity: falling
+  trigger_polarity: falling
 
   # Stretches and delays each trigger input signal for an number of clock cycles (corresponds to 6.25ns steps),
   # The stretch and delay of all inputs is given as a list,
@@ -50,8 +48,7 @@ trigger_inputs:
     delay: [0, 1, 0, 0, 3, 0]
 
 # Enable the LEMO clock output using a boolean.
-clock_lemo:
-  enable_clock_lemo_output: True
+enable_clock_lemo_output: True
 
 # Set the four PMT control voltages in V
 pmt_control:

--- a/aidatlu/test/fixtures/tlu_test_configuration.yaml
+++ b/aidatlu/test/fixtures/tlu_test_configuration.yaml
@@ -66,5 +66,5 @@ output_data_path: 'aidatlu/test/fixtures/test_output_data/'
 zmq_connection: off #"tcp://:7500"
 
 # Optional stop conditions these can be by timeout in seconds or a maximum output trigger number.
-max_trigger_number: None
+max_trigger_number:
 timeout: 5

--- a/aidatlu/test/test_configuration.py
+++ b/aidatlu/test/test_configuration.py
@@ -2,14 +2,15 @@ from pathlib import Path
 import os
 import yaml
 import pytest
-from aidatlu.main.config_parser import TLUConfigure
+from aidatlu.main.config_parser import Configure, yaml_parser
 from aidatlu.hardware.ioexpander_controller import IOControl
 from aidatlu.main.tlu import AidaTLU
 from aidatlu.hardware.i2c import I2CCore
 from aidatlu.test.utils import MockI2C
 
 FILEPATH = Path(__file__).parent
-CONFIG_FILE = FILEPATH / "fixtures" / "tlu_test_configuration.yaml"
+CONFIG_FILE_PATH = FILEPATH / "fixtures" / "tlu_test_configuration.yaml"
+CONFIG_FILE = yaml_parser(CONFIG_FILE_PATH)
 
 try:
     MOCK = not os.environ["HW"] == "True"
@@ -40,12 +41,12 @@ TLU = AidaTLU(
 def test_config_parser():
     """Test parsing the configuration file"""
 
-    config_parser = TLUConfigure(
-        TLU=TLU,
-        config_path=CONFIG_FILE,
+    config_parser = Configure(
+        tlu=TLU,
+        config_dict=CONFIG_FILE,
     )
-    with open(CONFIG_FILE) as yaml_file:
-        test_config = yaml.safe_load(yaml_file)
+    test_config = yaml_parser(CONFIG_FILE_PATH)
+
     assert isinstance(config_parser.get_configuration_table(), list)
     assert test_config["save_data"] == config_parser.get_data_handling()
     assert test_config["output_data_path"] == config_parser.get_output_data_path()
@@ -55,9 +56,9 @@ def test_config_parser():
 
 def test_dut_configuration():
     """Test configuration of the DUT interfaces"""
-    config_parser = TLUConfigure(
-        TLU=TLU,
-        config_path=CONFIG_FILE,
+    config_parser = Configure(
+        tlu=TLU,
+        config_dict=CONFIG_FILE,
     )
     config_parser.conf_dut()
 
@@ -83,9 +84,9 @@ def test_dut_configuration():
 
 def test_trigger_logic_configuration():
     """Test configuration of the trigger logic"""
-    config_parser = TLUConfigure(
-        TLU=TLU,
-        config_path=CONFIG_FILE,
+    config_parser = Configure(
+        tlu=TLU,
+        config_dict=CONFIG_FILE,
     )
     config_parser.conf_trigger_logic()
     if MOCK:
@@ -125,9 +126,9 @@ def test_trigger_logic_configuration():
 
 def test_trigger_input_configuration():
     """Test configuration of the trigger inputs"""
-    config_parser = TLUConfigure(
-        TLU=TLU,
-        config_path=CONFIG_FILE,
+    config_parser = Configure(
+        tlu=TLU,
+        config_dict=CONFIG_FILE,
     )
     config_parser.conf_trigger_inputs()
     if MOCK:
@@ -153,9 +154,9 @@ def test_trigger_input_configuration():
 
 def test_conf_auxillary():
     """Test PMT power and LEMO clock I/O"""
-    config_parser = TLUConfigure(
-        TLU=TLU,
-        config_path=CONFIG_FILE,
+    config_parser = Configure(
+        tlu=TLU,
+        config_dict=CONFIG_FILE,
     )
     config_parser.conf_auxillary()
 

--- a/aidatlu/test/test_configuration.py
+++ b/aidatlu/test/test_configuration.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 import os
-import yaml
 import pytest
-from aidatlu.main.config_parser import Configure, yaml_parser
+from aidatlu.main.config_parser import Configure, yaml_parser, toml_parser
 from aidatlu.hardware.ioexpander_controller import IOControl
 from aidatlu.main.tlu import AidaTLU
 from aidatlu.hardware.i2c import I2CCore
@@ -45,13 +44,14 @@ def test_config_parser():
         tlu=TLU,
         config_dict=CONFIG_FILE,
     )
-    test_config = yaml_parser(CONFIG_FILE_PATH)
-
     assert isinstance(config_parser.get_configuration_table(), list)
-    assert test_config["save_data"] == config_parser.get_data_handling()
-    assert test_config["output_data_path"] == config_parser.get_output_data_path()
-    assert (None, test_config["timeout"]) == config_parser.get_stop_condition()
-    assert test_config["zmq_connection"] == config_parser.get_zmq_connection()
+    assert CONFIG_FILE["save_data"] == config_parser.get_data_handling()
+    assert CONFIG_FILE["output_data_path"] == config_parser.get_output_data_path()
+    assert (None, CONFIG_FILE["timeout"]) == config_parser.get_stop_condition()
+    assert CONFIG_FILE["zmq_connection"] == config_parser.get_zmq_connection()
+
+    config_toml_path = FILEPATH / "fixtures" / "tlu_test_configuration.toml"
+    assert toml_parser(config_toml_path) == yaml_parser(CONFIG_FILE_PATH)
 
 
 def test_dut_configuration():

--- a/aidatlu/test/test_tlu.py
+++ b/aidatlu/test/test_tlu.py
@@ -5,10 +5,11 @@ import pytest
 from aidatlu.main.tlu import AidaTLU
 from aidatlu.hardware.i2c import I2CCore
 from aidatlu.test.utils import MockI2C
+from aidatlu.main.config_parser import yaml_parser
 
 FILEPATH = Path(__file__).parent
-CONFIG_FILE = FILEPATH / "fixtures" / "tlu_test_configuration.yaml"
-
+CONFIG_FILE_PATH = FILEPATH / "fixtures" / "tlu_test_configuration.yaml"
+CONFIG_FILE = yaml_parser(CONFIG_FILE_PATH)
 try:
     MOCK = not os.environ["HW"] == "True"
 except KeyError:

--- a/aidatlu/tlu_configuration.yaml
+++ b/aidatlu/tlu_configuration.yaml
@@ -13,6 +13,7 @@ dut_module:
   dut_4:
     mode: off
 
+trigger_inputs:
   # Threshold voltages for the trigger inputs in V.
   threshold:
     threshold_1: -0.1
@@ -25,10 +26,10 @@ dut_module:
   # Trigger Logic configuration accept a python expression for the trigger inputs.
   # The logic is set by using the variables for the input channels 'CH1', 'CH2', 'CH3', 'CH4', 'CH5' and 'CH6'
   # and the Python bitwise operators AND: '&', OR: '|', NOT: 'not' and so on. Dont forget to use brackets...
-  trigger_inputs_logic: CH2 & CH4
+  trigger_inputs_logic: 'CH1 & CH2'
 
   # TLU can trigger on a rising or falling edge. Trigger polarity is set using a string or boolean,
-  # 'rising' corresponds to false (0) and 'falling' to true (1)
+  # 'rising' corresponds to false and 'falling' to true
   trigger_polarity: falling
 
   # Stretches and delays each trigger input signal for an number of clock cycles (corresponds to 6.25ns steps),
@@ -39,7 +40,7 @@ dut_module:
     delay: [0, 0, 0, 0, 0, 0]
 
 # Enable the LEMO clock output using a boolean.
-enable_clock_lemo_output: on
+enable_clock_lemo_output: True
 
 # Set the four PMT control voltages in V
 pmt_control:
@@ -54,10 +55,10 @@ save_data: True
 output_data_path:
 
 # zmq connection for status messages, leave it blank or set to off if not needed
-zmq_connection: off  #"tcp://127.0.0.1:6500"
+zmq_connection: off #"tcp://:7500"
 
 # Optional stop conditions can also be added to the configuration.
-# These can be a timeout in seconds or a maximum output trigger number.
+# These can be by timeout in seconds or a maximum output trigger number.
 # If needed just uncomment the required stop condition in the example below:
 # max_trigger_number: 1000000
-# timeout: 60
+# timeout: 5

--- a/aidatlu/tlu_configuration.yaml
+++ b/aidatlu/tlu_configuration.yaml
@@ -57,8 +57,6 @@ output_data_path:
 # zmq connection for status messages, leave it blank or set to off if not needed
 zmq_connection: off #"tcp://:7500"
 
-# Optional stop conditions can also be added to the configuration.
-# These can be by timeout in seconds or a maximum output trigger number.
-# If needed just uncomment the required stop condition in the example below:
-# max_trigger_number: 1000000
-# timeout: 5
+# Optional stop conditions these can be by timeout in seconds or a maximum output trigger number.
+max_trigger_number: None
+timeout: None

--- a/aidatlu/tlu_configuration.yaml
+++ b/aidatlu/tlu_configuration.yaml
@@ -1,6 +1,5 @@
 # Generate TLU internal trigger with given rate in Hz
-internal_trigger:
-  internal_trigger_rate: 0
+internal_trigger_rate: 0
 
 # Set operating mode of the DUT, supported are three operating modes 'aida', 'aidatrig' and 'eudet'
 # Set unused DUT interfaces to off, false or None
@@ -14,7 +13,6 @@ dut_module:
   dut_4:
     mode: off
 
-trigger_inputs:
   # Threshold voltages for the trigger inputs in V.
   threshold:
     threshold_1: -0.1
@@ -31,19 +29,17 @@ trigger_inputs:
 
   # TLU can trigger on a rising or falling edge. Trigger polarity is set using a string or boolean,
   # 'rising' corresponds to false (0) and 'falling' to true (1)
-  trigger_polarity:
-    polarity: falling
+  trigger_polarity: falling
 
-# Stretches and delays each trigger input signal for an number of clock cycles (corresponds to 6.25ns steps),
-# The stretch and delay of all inputs is given as a list,
-# each entry corresponding to an individual trigger input.
+  # Stretches and delays each trigger input signal for an number of clock cycles (corresponds to 6.25ns steps),
+  # The stretch and delay of all inputs is given as a list,
+  # each entry corresponding to an individual trigger input.
   trigger_signal_shape:
     stretch: [2, 2, 2, 2, 2, 2]
     delay: [0, 0, 0, 0, 0, 0]
 
 # Enable the LEMO clock output using a boolean.
-clock_lemo:
-  enable_clock_lemo_output: on
+enable_clock_lemo_output: on
 
 # Set the four PMT control voltages in V
 pmt_control:


### PR DESCRIPTION
Flattend some unnecessary keys in the configuration file in preparation for the constellation integration. 

Now the TLU main class requires a flat dictionary as input instead of file path to a `yaml`.
Different files can be formatted with parser functions into the specific dictionary format.
This way, the TLU can use different configuration files structures. 
For now a `yaml` and a `toml` format will be implemented.