### PR TITLE
BUG: fixed yaml dep + wrong test data output dir

### DIFF
--- a/aidatlu/test/fixtures/tlu_test_configuration.yaml
+++ b/aidatlu/test/fixtures/tlu_test_configuration.yaml
@@ -63,7 +63,7 @@ pmt_control:
 # Save and generate interpreted data from the raw data set. Set to 'True' or 'False'.
 # If no specific output path is provided, the data is saved in the default output data path (aidatlu/aidatlu/tlu_data).
 save_data: True
-output_data_path: 'test_output_data/'
+output_data_path: 'aidatlu/test/fixtures/test_output_data/'
 
 # zmq connection for status messages, leave it blank or set to off if not needed
 zmq_connection: off #"tcp://:7500"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "tables",
     "coloredlogs",
     "pyzmq",
-    "tqdm"
+    "tqdm",
+    "PyYAML",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixed the missing `pyyaml` dependency.
Also during test raw data files were created at the wrong directory. These are now saved in `test/fixtures`.