### PR TITLE
ENH: run coverage with pytest in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,4 +23,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest -sv
+          pytest -sv --force-sugar --cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 hw = ["online_monitor"]  # uhal package needs to be installed manually!
-test = ["pytest", "coverage"]
+test = ["pytest", "pytest-cov", "pytest-sugar"]
 doc = ["sphinx", "myst_parser", "sphinx_mdinclude", "pydata-sphinx-theme"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Run coverage using `pytest-cov` (uses the `coverage` package but adds a `--cov` option). I also added `pytest-sugar` for a nicer and more colorful output.