### PR TITLE
MAINT: removed support for python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 license = { "text" = "AGPL-3.0" }
 description = "Control software for AIDA-2020 TLU"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     {name = "Rasmus Partzsch", email="rasmus.partzsch@uni-bonn.de"},
     {name = "Christian Bespin", email="cbespin@uni-bonn.de"}


### PR DESCRIPTION
Removed support for Python 3.10.
The TOML library `tomllib` is not supported on 3.10, so to avoid additional dependencies we could stop support for Python 3.10.