### PR TITLE
ENH: custom clock config files in constellation

### DIFF
--- a/aidatlu/constellation/README.md
+++ b/aidatlu/constellation/README.md
@@ -78,6 +78,7 @@ SatelliteAidaTLU -g testbeam -n TLU
 | `trigger_signal_delay` | (Required) Delays each individual trigger input by a given number of clock cycles (corresponds to `6.25ns` steps) | List | None |
 | `enable_clock_lemo_output` | (Optional) Enable the LEMO clock output. | String | False |
 | `pmt_power` | (Required) Sets the four PMT control voltages in V | List | None |
+| `clock_config` | (Optional) Specify a custom clock configuration. If no path is provided the TLU uses the default configuration. | String | `aidatlu/misc/aida_tlu_clk_config.txt` |
 
 ### Configuration Example
 An example configuration for the AIDA-TLU satellite which could be dropped into a Constellation configuration as a starting point.

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -118,7 +118,11 @@ class AidaTLU(DataSender):
     def _init_tlu(self, config: Configuration) -> None:
         "Parse configuration file to TLU and initialize, set loggers"
         self.config_file = toml_parser(config, constellation=True)
-        self.clock_file = str(self.file_path) + "/../misc/aida_tlu_clk_config.txt"
+        if self.config_file["clock_config"] in [None, "None", False]:
+            self.log.info("No clock configuration provided, using default file")
+            self.clock_file = str(self.file_path) + "/../misc/aida_tlu_clk_config.txt"
+        else:
+            self.clock_file = self.config_file["clock_config"]
         self.aidatlu = TLU(
             self.hw, self.config_file, self.clock_file, i2c=self.i2c_method
         )

--- a/aidatlu/hardware/clock_controller.py
+++ b/aidatlu/hardware/clock_controller.py
@@ -80,7 +80,7 @@ class ClockControl:
         self.i2c.write(self.i2c.modules["clk"], address, data)
 
     def parse_clock_conf(self, file_path: str) -> list:
-        """reads the clock config file and returns a panda dataframe with two rows Address and Data
+        """reads the clock config file and returns a list with two rows Address and Data
            The configuration file is produced by Clockbuilder Pro (Silicon Labs).
 
         Args:
@@ -91,7 +91,11 @@ class ClockControl:
         """
         with open(file_path, newline="") as clk_conf:
             contents = clk_conf.read().splitlines()
-            contents = [row.split(",") for row in contents[10:]]
+            contents = [
+                row.split(",")
+                for row in contents
+                if not row.startswith("#") and not row.startswith("Address")
+            ]
         return contents
 
     def write_clock_conf(self, file_path: str) -> None:

--- a/aidatlu/main/config_parser.py
+++ b/aidatlu/main/config_parser.py
@@ -425,4 +425,10 @@ def toml_parser(conf_file_path: str, constellation: bool = False) -> dict:
         conf["timeout"] = None
         conf["save_data"] = False
 
+        # Loads custom clock configuration file if provided
+        try:
+            conf["clock_config"] = toml_conf["clock_config"]
+        except:
+            conf["clock_config"] = None
+
     return conf


### PR DESCRIPTION
A custom clock configuration file can be used in constellation. If no clock configuration path is provided the TLU uses the usual default clock configuration. This features is only implemented when using constellation.