### PR TITLE
Fix: Write Clock File

### DIFF
--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -136,6 +136,8 @@ class AidaTLU(TransmitterSatellite):
         else:
             self.clock_file = self.config_file["clock_config"]
         self.aidatlu = TLU(self.hw, i2c=self.i2c_method)
+        self.aidatlu.write_clock_config(self.clock_file)
+
         self.config_parser = Configure(self.aidatlu, self.config_file)
         self.aidatlu.reset_configuration()
         # Resets aidatlu loggers and replaces them with constellation loggers


### PR DESCRIPTION
I noticed that the method `write_clock_config` of the TLU controller is never called from the satellite, only from the regular Python code. So to me it looks like the clock file was never configured.

Could this be the issue @stephanlachnit reported in #46 ?