### PR TITLE
Removed log spam in constellation

### DIFF
--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -199,7 +199,7 @@ class AidaTLU(TransmitterSatellite):
         self.last_post_veto_trigger = self.aidatlu.get_post_veto_trigger_number()
         self.last_pre_veto_trigger = self.aidatlu.get_pre_veto_trigger_number()
 
-        self.log.info(
+        self.log.debug(
             "Run time: %.1f s, Pre veto: %s, Post veto: %s, Pre veto rate: %.f Hz, Post veto rate.: %.f Hz"
             % (
                 self.run_time,


### PR DESCRIPTION
I just moved the status log message to the debug level. 

But I think a better way to do this is perhaps to check for the observatory log level and disable the complete [log status function](https://github.com/SiLab-Bonn/aidatlu/blob/const-log-spam/aidatlu/constellation/aidatlu_satellite.py#L177). Is there a way to check for the observatory log level in the satellite?