### PR TITLE
Status Interval

### DIFF
--- a/aidatlu/constellation/README.md
+++ b/aidatlu/constellation/README.md
@@ -74,6 +74,7 @@ This means DUT interface signals (e.g. clock signals) are disrupted during these
 | `enable_clock_lemo_output` | (Optional) Enable the LEMO clock output. | String | False |
 | `pmt_power` | (Required) Sets the four PMT control voltages in V | List | None |
 | `clock_config` | (Optional) Specify a custom clock configuration. If no path is provided, the TLU uses the default configuration. | String | None |
+| `status_interval` | (Optional) Set status calculation interval in seconds. Affects logging and calculation interval (pre and post trigger rates).| float | 1 |
 
 The default clock configuration can be found in [`aidatlu/misc/aida_tlu_clk_config.txt`](https://github.com/SiLab-Bonn/aidatlu/blob/main/aidatlu/misc/aida_tlu_clk_config.txt).
 

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -32,6 +32,12 @@ class AidaTLU(TransmitterSatellite):
             ", ".join(config.get_keys()),
         )
 
+        try:
+            self.status_interval = config["status_interval"]
+        except:
+            self.status_interval = 1
+        self.log.debug("Calculating status every %.3f s" % self.status_interval)
+
         self.file_path = Path(__file__).parent
 
         if not self.use_mock:
@@ -183,12 +189,22 @@ class AidaTLU(TransmitterSatellite):
             time.sleep(0.5)
             last_time = self.tlu_controller.get_timestamp()
             current_time = (last_time - self.start_time) * 25 / 1000000000
-            # Logs and poss. sends status every 1s.
-            if current_time - self.last_time > 1:
-                self.log_status(current_time)
+            # Calculate and poss. sends status every self.status_interval seconds.
+            if current_time - self.last_time > self.status_interval:
+                self.check_status(current_time)
+                self.log.debug(
+                    "Run time: %.1f s, Pre veto: %s, Post veto: %s, Pre veto rate: %.f Hz, Post veto rate.: %.f Hz"
+                    % (
+                        self.run_time,
+                        self.total_pre_veto,
+                        self.total_post_veto,
+                        self.pre_veto_rate,
+                        self.post_veto_rate,
+                    )
+                )
 
-    def log_status(self, time: int) -> None:
-        """Logs the status of the TLU run with runtime, pre- and post-veto numbers/rates.
+    def check_status(self, time: int) -> None:
+        """Calculates operation status of the TLU run with runtime, pre- and post-veto numbers/rates.
            Also calculates the mean trigger frequency between function calls.
 
         Args:
@@ -211,16 +227,6 @@ class AidaTLU(TransmitterSatellite):
         self.last_post_veto_trigger = self.tlu_controller.get_post_veto_trigger_number()
         self.last_pre_veto_trigger = self.tlu_controller.get_pre_veto_trigger_number()
 
-        self.log.debug(
-            "Run time: %.1f s, Pre veto: %s, Post veto: %s, Pre veto rate: %.f Hz, Post veto rate.: %.f Hz"
-            % (
-                self.run_time,
-                self.total_pre_veto,
-                self.total_post_veto,
-                self.pre_veto_rate,
-                self.post_veto_rate,
-            )
-        )
         if self.tlu_controller.get_event_fifo_csr() == 0x10:
             self.log.warning("FIFO is full")
 

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -32,10 +32,8 @@ class AidaTLU(TransmitterSatellite):
             ", ".join(config.get_keys()),
         )
 
-        try:
-            self.status_interval = config["status_interval"]
-        except:
-            self.status_interval = 1
+        config.set_default(key="status_interval", value=1)
+        self.status_interval = config["status_interval"]
         self.log.debug("Calculating status every %.3f s" % self.status_interval)
 
         self.file_path = Path(__file__).parent


### PR DESCRIPTION
Added the possibility to set the interval in which the TLU status is calculated in responds to [#73](https://github.com/SiLab-Bonn/aidatlu/issues/73) This interval can only be set for the constellation satellite. If not explicitly stated the status interval defaults to 1s. In addition, I split status logging and calculations. 