### PR TITLE
TLU satellite configures during initializing

### DIFF
--- a/aidatlu/constellation/README.md
+++ b/aidatlu/constellation/README.md
@@ -101,6 +101,12 @@ The following metrics are distributed by this satellite and can be subscribed to
 | `SC5` | Total number that trigger input 5 received a valid signal | Integer | 1s |
 | `SC6` | Total number that trigger input 6 received a valid signal | Integer | 1s |
 
+## Custom Commands
+
+| Command | Description | Arguments | Return Value | Allowed States |
+|---------|-------------|-----------|--------------|----------------|
+| `reset_counters` | Resets all internal counters of the TLU | - | String | `INIT`, `ORBIT`, `RUN` |
+
 ## Data
 
 This satellite sends the raw data read from the TLU FIFO, consisting of six 32bit words with the following data:

--- a/aidatlu/constellation/README.md
+++ b/aidatlu/constellation/README.md
@@ -40,8 +40,8 @@ SatelliteAidaTLU -g testbeam -n TLU
 ```
 
 ```{note}
-The TLU configuration resets during launching and landing.
-This means DUT interface signals (e.g. clock signals) are disrupted during these transitions.
+The TLU configuration resets during initializing.
+This means DUT interface signals (e.g. clock signals) are disrupted here.
 ```
 
 ## Parameters

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -12,6 +12,7 @@ from constellation.core.configuration import Configuration
 from constellation.core.message.cscp1 import SatelliteState
 from constellation.core.monitoring import schedule_metric
 from constellation.core.transmitter_satellite import TransmitterSatellite
+from constellation.core.commandmanager import cscp_requestable
 
 from aidatlu.hardware.i2c import I2CCore
 from aidatlu.main.config_parser import toml_parser
@@ -75,15 +76,6 @@ class AidaTLU(TransmitterSatellite):
 
     def do_landing(self) -> str:
         return "Do landing complete"
-
-    def do_reconfigure(self, config: Configuration) -> str:
-        self.tlu_controller.reset_fifo()
-        self.tlu_controller.reset_timestamp()
-        self.tlu_controller.get_event_fifo_fill_level()
-        self.tlu_controller.get_event_fifo_csr()
-        self.tlu_controller.reset_counters()
-        self.tlu_controller.get_scalers()
-        return "Do reconfigure complete"
 
     def do_starting(self, run_identifier: str = None) -> str:
         if self.use_mock:
@@ -270,6 +262,16 @@ class AidaTLU(TransmitterSatellite):
 
         if self.tlu_controller.get_event_fifo_csr() == 0x10:
             self.log.warning("FIFO is full")
+
+    @cscp_requestable
+    def reset_counters(self) -> str:
+        self.tlu_controller.reset_fifo()
+        self.tlu_controller.reset_timestamp()
+        self.tlu_controller.get_event_fifo_fill_level()
+        self.tlu_controller.get_event_fifo_csr()
+        self.tlu_controller.reset_counters()
+        self.tlu_controller.get_scalers()
+        return "Counters reset"
 
     @schedule_metric("Hz", 1)
     def pre_veto_rate(self) -> float | None:

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -57,15 +57,16 @@ class AidaTLU(TransmitterSatellite):
             self.hw = None
 
         self._init_tlu(configuration)
-
+        self.tlu_configure.configure()
+        self.tlu_controller.get_event_fifo_fill_level()
+        self.tlu_controller.get_event_fifo_csr()
+        self.tlu_controller.reset_counters()
+        self.tlu_controller.get_scalers()
         return "Initializing complete"
 
     def do_launching(self, payload: Any = None) -> str:
-        self.tlu_controller.reset_counters()
         self.tlu_controller.reset_fifo()
         self.tlu_controller.reset_timestamp()
-        self.tlu_configure.configure()
-        self.conf_list = self.tlu_configure.get_configuration_table()
         self.tlu_controller.get_event_fifo_fill_level()
         self.tlu_controller.get_event_fifo_csr()
         self.tlu_controller.reset_counters()
@@ -73,12 +74,16 @@ class AidaTLU(TransmitterSatellite):
         return "Do launching complete"
 
     def do_landing(self) -> str:
-        self.tlu_controller.reset_configuration()
         return "Do landing complete"
 
     def do_reconfigure(self, config: Configuration) -> str:
         configuration = self._read_config(config)
         self._init_tlu(configuration)
+        self.tlu_configure.configure()
+        self.tlu_controller.get_event_fifo_fill_level()
+        self.tlu_controller.get_event_fifo_csr()
+        self.tlu_controller.reset_counters()
+        self.tlu_controller.get_scalers()
         return "Do reconfigure complete"
 
     def do_starting(self, run_identifier: str = None) -> str:

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -265,7 +265,7 @@ class AidaTLU(TransmitterSatellite):
 
         if self.tlu_controller.get_event_fifo_csr() == 0x10:
             self.log.warning("FIFO is full")
-            
+
     @cscp_requestable([SatelliteState.ORBIT])
     def reset_counters(self) -> tuple[str, Any, dict[str, Any]]:
         self.tlu_controller.reset_fifo()
@@ -274,8 +274,8 @@ class AidaTLU(TransmitterSatellite):
         self.tlu_controller.get_event_fifo_csr()
         self.tlu_controller.reset_counters()
         self.tlu_controller.get_scalers()
-        return "Counters reset"
-      
+        return "Counters reset", None, {}
+
     @schedule_metric("Hz", 1, [SatelliteState.RUN])
     def pre_veto_rate(self) -> float:
         return self._pre_veto_rate

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -263,8 +263,8 @@ class AidaTLU(TransmitterSatellite):
         if self.tlu_controller.get_event_fifo_csr() == 0x10:
             self.log.warning("FIFO is full")
 
-    @cscp_requestable
-    def reset_counters(self) -> str:
+    @cscp_requestable([SatelliteState.ORBIT])
+    def reset_counters(self) -> tuple[str, Any, dict[str, Any]]:
         self.tlu_controller.reset_fifo()
         self.tlu_controller.reset_timestamp()
         self.tlu_controller.get_event_fifo_fill_level()

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -77,9 +77,8 @@ class AidaTLU(TransmitterSatellite):
         return "Do landing complete"
 
     def do_reconfigure(self, config: Configuration) -> str:
-        configuration = self._read_config(config)
-        self._init_tlu(configuration)
-        self.tlu_configure.configure()
+        self.tlu_controller.reset_fifo()
+        self.tlu_controller.reset_timestamp()
         self.tlu_controller.get_event_fifo_fill_level()
         self.tlu_controller.get_event_fifo_csr()
         self.tlu_controller.reset_counters()


### PR DESCRIPTION
By configuring the TLU earlier clocks are not interrupted during launching. 
Devices that depend on this clock are now easier to handle.

Solves #68 and #84.