### PR TITLE
Entry point for Stand-alone Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ The default IP address of the TLU is:
 ```
 192.168.200.30
 ```
-## Python packages
-Install the Python package as usual.
+## Python Packages
+
+### From Source
+After cloning the repository, install the Python packages as usual.
 ```bash
 pip install -e .
 ```
@@ -49,36 +51,45 @@ To connect to the hardware, you need to install the `hw` component as well.
 pip install -e .[hw]
 ```
 
-# Usage
-There are multiple ways to use the control software of the AIDA 2020 TLU.
-If one executes tlu.py in the main directory, the TLU is initialized, configured and starts a run automatically.
+### From PyPI
 ```bash
-    python tlu.py
+pip install aidatlu
 ```
-The TLU is configured with the standard tlu_configuration file. To stop the run use ctrl+c.
 
+# Usage
 
-While configuring the TLU outputs are powered on and off.
-This leads to problems in AIDA mode where the clock is powered off shortly during configuration.
-To avoid this at the start of runs in AIDA mode the best way is to use the aidatlu_run.py script.
-This is started and controlled with the terminal input:
+## Standalone Python Implementation
+Connect to the TLU, configure and start a run via:
+```bash
+    pyaidatlu -c path/to/configuration.yaml
+```
+All configurations are done by the use of a [yaml file](https://github.com/SiLab-Bonn/aidatlu/tree/main/aidatlu).
+To stop the run use `ctrl+c`.
+
+After installing from source, it is also possible to control the TLU via IPython:
 ```bash
     python -i aidatlu_run.py
 ```
-This initializes the main tlu.py script. One is now able to control the TLU through the Python terminal interface,
+One is now able to control the TLU through the Python terminal interface,
 with the following commands:
 ```bash
     tlu.configure()
     tlu.run()
-    tlu.help()
 ```
-Naturally, this also works for any EUDET mode runs.
-Runs are stopped with the keyboard interrupt ctr+c.
-For more commands take a look at the python script aidatlu.py.
-
-All configurations are done by the use of a yaml file (tlu_configuration.yaml).
+Runs are stopped with the keyboard interrupt `ctr+c`.
+## Constellation
+Start a satellite with:
+```bash
+    SatelliteAidaTLU -g testbeam -n TLU
+```
+For more information take a look at the [constellation readme](https://github.com/SiLab-Bonn/aidatlu/tree/main/aidatlu/constellation).
 
 # Tests
+Test the software by using the TLU mock.
+Just set the environment variable:
+```bash
+    TEST=True pyaidatlu -c path/to/configuration.yaml
+```
 With [pytest](https://docs.pytest.org/en/stable/) the AIDA TLU control program can be tested.
 There is also an implemented AIDA-TLU mock, to allow tests and software development without hardware,
 which also allows software development and testing without a working IPbus installation.
@@ -91,10 +102,4 @@ To test with connected hardware set an environment variable ```HW=True````:
 
 ```bash
     HW=True pytest -sv
-```
-
-You can also set the variable ```HW=False```` to test the mock TLU:
-
-```bash
-    HW=False pytest -sv
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ The software is a lightweight version written in Python with a focus on readabil
 Most user cases can be set with a .yaml configuration file and started by executing a single Python script.
 For a more in-depth look at the hardware components please take a look at the official [AIDA-2020 TLU project](https://gitlab.com/ohwr/project/fmc-mtlu).
 Additionally, take a look at the [documentation](https://silab-bonn.github.io/aidatlu/) for this software.
+
 # Installation
+
 ## IPbus
 You need to install the ControlHub from the [IPbus](https://ipbus.web.cern.ch/doc/user/html/software/install/compile.html) software.
 Follow the linked tutorial for prerequisites and general installation.
@@ -58,7 +60,7 @@ pip install aidatlu
 
 # Usage
 
-## Standalone Python Implementation
+## Stand-Alone Python Implementation
 Connect to the TLU, configure and start a run via:
 ```bash
     pyaidatlu -c path/to/configuration.yaml
@@ -77,6 +79,7 @@ with the following commands:
     tlu.run()
 ```
 Runs are stopped with the keyboard interrupt `ctr+c`.
+
 ## Constellation
 Start a satellite with:
 ```bash
@@ -85,7 +88,8 @@ Start a satellite with:
 For more information take a look at the [constellation readme](https://github.com/SiLab-Bonn/aidatlu/tree/main/aidatlu/constellation).
 
 # Tests
-Test the software by using the TLU mock.
+
+Test the software by using a TLU mock.
 Just set the environment variable:
 ```bash
     TEST=True pyaidatlu -c path/to/configuration.yaml
@@ -98,7 +102,7 @@ The mock is used as a default.
 ```bash
     pytest -sv
 ```
-To test with connected hardware set an environment variable ```HW=True````:
+To test with connected hardware set an environment variable:
 
 ```bash
     HW=True pytest -sv

--- a/aidatlu/aidatlu_run.py
+++ b/aidatlu/aidatlu_run.py
@@ -1,12 +1,17 @@
 import os
 import time
+import argparse
+from pathlib import Path
 
 import uhal
-from main.tlu import AidaTLU
-from main.config_parser import yaml_parser
+from aidatlu.main.tlu import AidaTLU
+from aidatlu.main.config_parser import yaml_parser
 import aidatlu.logger as logger
-from test.utils import MockI2C
-from hardware.i2c import I2CCore
+from aidatlu.test.utils import MockI2C
+from aidatlu.hardware.i2c import I2CCore
+
+
+FILEPATH = Path(__file__).parent
 
 
 class AIDATLU:
@@ -18,7 +23,6 @@ class AIDATLU:
         print(r" /_/ \_\___|___/_/ \_\   |_| |____\___/ ")
         print(r"                                        ")
         print(r"----------------------------------------")
-        print("tlu.help()\n")
 
         self.config_file = config_path
         self.clock_file = clock_path
@@ -62,13 +66,16 @@ class AIDATLU:
         conf_dict = yaml_parser(self.config_file)
         try:
             self.MOCK = os.environ["TEST"] == "True"
+            I2CMETHOD = MockI2C
+            hw = None
         except KeyError:
             self.MOCK = False
             I2CMETHOD = I2CCore
-
-        if self.MOCK:
-            I2CMETHOD = MockI2C
-            hw = None
+            uhal.setLogLevelTo(uhal.LogLevel.NOTICE)
+            manager = uhal.ConnectionManager(
+                "file://" + str(FILEPATH) + "/misc/aida_tlu_connection.xml"
+            )
+            hw = uhal.HwInterface(manager.getDevice("aida_tlu.controlhub"))
 
         self.aidatlu = AidaTLU(hw, conf_dict, self.clock_file, i2c=I2CMETHOD)
 
@@ -80,17 +87,30 @@ class AIDATLU:
         print("for access to the main tlu functions: tlu.aidatlu....")
 
 
-if __name__ == "__main__":
-    uhal.setLogLevelTo(uhal.LogLevel.NOTICE)
-    manager = uhal.ConnectionManager("file://./misc/aida_tlu_connection.xml")
-    hw = uhal.HwInterface(manager.getDevice("aida_tlu.controlhub"))
+def start():
+    parser = argparse.ArgumentParser(
+        prog="aidatlu",
+        description="Control the 2020-Aida-TLU using a Python based interface.",
+    )
+    parser.add_argument(
+        "-c", "--config", type=str, help="Path to configuration yaml", nargs="*"
+    )
+    args = vars(parser.parse_args())
 
+    config_path = args["config"][0]
+    clock_path = str(FILEPATH) + "/misc/aida_tlu_clk_config.txt"
+
+    logger.setup_main_logger(name="AIDA-TLU", level="INFO")
+    tlu = AIDATLU(config_path, clock_path)
+    tlu.configure()
+    tlu.run()
+
+
+if __name__ == "__main__":
     config_path = "tlu_configuration.yaml"
     clock_path = "misc/aida_tlu_clk_config.txt"
 
     logger.setup_main_logger(name="AIDA-TLU", level="INFO")
     tlu = AIDATLU(config_path, clock_path)
 
-    # Uncomment if you just want to use EUDET mode and just plug and play TLU.
-    # tlu.configure
-    # tlu.run
+    print("tlu.help()")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ doc = ["sphinx", "myst_parser", "sphinx_mdinclude", "pydata-sphinx-theme", "sphi
 version = {attr = "aidatlu.__version__"}
 
 [project.scripts]
+pyaidatlu = "aidatlu.aidatlu_run:start"
 SatelliteAidaTLU = "aidatlu.constellation.__main__:main"
 
 [project.entry-points."constellation.satellites"]


### PR DESCRIPTION
Added Python script for stand-alone implementation, this is necessary when installing via PyPI.
Configure the TLU and start a run simply by:
`pyaidatlu -c /path/to/configuration.yaml`.