### PR TITLE
Add support to set DUTMaskModeModifier on DUT channels to constellation satellite

### DIFF
--- a/aidatlu/README.md
+++ b/aidatlu/README.md
@@ -9,7 +9,7 @@ To disable the generation of internal triggers set this frequency to zero.
 ### DUT Module (dut_module)
 The DUT module configures the individual DUT interfaces.
 Where each interface can be set to one operating mode.
-The possible modes are 'aida', 'aidatrig' and 'eudet'.
+The possible modes are 'aida', 'aidatrig', 'eudet' and 'eudet_with_busy'.
 With 'aidatrig' the AIDA mode with additional trigger number.
 And 'aida' or 'eudet' the AIDA or EUDET operating modes.
 It is important to note that only working DUT devices should be enabled.

--- a/aidatlu/constellation/README.md
+++ b/aidatlu/constellation/README.md
@@ -49,7 +49,7 @@ This means DUT interface signals (e.g. clock signals) are disrupted here.
 | Configuration | Description | Type | Default Value |
 |-----------|-------------|------| ------|
 | `internal_trigger_rate` | (Optional) Generates internal triggers with a given frequency given in Hz. | Integer | 0 |
-| `dut_interfaces` | (Required) Specify the operation mode of the DUT interface (`aida`, `eudet`, `aidatrig`, `off`), given as list with a required length of 4. `aida` and `eudet` correspond to the classic AIDA and EUDET mode respectively and `aidatrig` to the AIDA-mode with handshake. Disable a DUT interface with `off`. | List | None |
+| `dut_interfaces` | (Required) Specify the operation mode of the DUT interface (`aida`, `eudet`, `aidatrig`, `eudet_with_busy`, `off`), given as list with a required length of 4. `aida` and `eudet` correspond to the classic AIDA and EUDET mode respectively and `aidatrig` to the AIDA-mode with handshake. `eudet_with_busy` additionally allows an asserted DUTClk from the device to produce a global veto. Disable a DUT interface with `off`. | List | None |
 | `ignore_busy` | (Optional) Specific DUT interface ignores busy signals. | List | `[false, false, false, false]` |
 | `trigger_threshold` | (Required) Threshold setting of each individual trigger input channel given in V. | List | None |
 | `trigger_inputs_logic` | (Required) Trigger Logic configuration accepts a Python expression for the trigger inputs. The logic is set by using the variables for the input channels `CH1`, `CH2`, `CH3`, `CH4`, `CH5` and `CH6` and the Python logic operators `and`, `or`, `not` and so on. Don't forget to use brackets... | String | None |

--- a/aidatlu/constellation/aidatlu_satellite.py
+++ b/aidatlu/constellation/aidatlu_satellite.py
@@ -22,6 +22,7 @@ from aidatlu.test.utils import MockI2C
 
 class DUTInterfaceType(StrEnum):
     EUDET = "eudet"
+    EUDET_WITH_BUSY = "eudet_with_busy"
     AIDA = "aida"
     AIDATRIG = "aidatrig"
     OFF = "off"

--- a/aidatlu/hardware/tlu_controller.py
+++ b/aidatlu/hardware/tlu_controller.py
@@ -287,11 +287,18 @@ class TLUConfigure:
         """Parse the configuration for the DUT interface to the AIDATLU."""
         dut = [0, 0, 0, 0]
         dut_mode = [0, 0, 0, 0]
+        dut_mode_modifier = [0, 0, 0, 0]
         ignore_busy = 0
         for i in range(4):
             if self.conf["DUT_%s" % (i + 1)] == "eudet":
                 self.tlu.io_controller.switch_led(i + 1, "g")
                 dut[i] = 2**i
+                # Clock output needs to be disabled for EUDET mode.
+                self.tlu.io_controller.clock_hdmi_output(i + 1, "off")
+            if self.conf["DUT_%s" % (i + 1)] == "eudet_with_busy":
+                self.tlu.io_controller.switch_led(i + 1, "g")
+                dut[i] = 2**i
+                dut_mode_modifier[i] = 2**i
                 # Clock output needs to be disabled for EUDET mode.
                 self.tlu.io_controller.clock_hdmi_output(i + 1, "off")
             if self.conf["DUT_%s" % (i + 1)] == "aidatrig":
@@ -333,7 +340,7 @@ class TLUConfigure:
             % (dut_mode[0] | dut_mode[1] | dut_mode[2] | dut_mode[3])
         )
         # Special configs
-        self.tlu.dut_logic.set_dut_mask_mode_modifier(0)
+        self.tlu.dut_logic.set_dut_mask_mode_modifier(dut_mode_modifier[0] | dut_mode_modifier[1] | dut_mode_modifier[2] | dut_mode_modifier[3])
         self.tlu.dut_logic.set_dut_ignore_busy(ignore_busy)
         self.tlu.dut_logic.set_dut_ignore_shutter(0x1)
 

--- a/aidatlu/tlu_configuration.yaml
+++ b/aidatlu/tlu_configuration.yaml
@@ -1,7 +1,7 @@
 # Generate TLU internal trigger with given rate in Hz
 internal_trigger_rate: 0
 
-# Set operating mode of the DUT, supported are three operating modes 'aida', 'aidatrig' and 'eudet'
+# Set operating mode of the DUT, supported are three operating modes 'aida', 'aidatrig', 'eudet', and 'eudet_with_busy'
 # Set unused DUT interfaces to off, false or None
 dut_module:
   dut_1:


### PR DESCRIPTION
The AIDA TLU Constellation satellite currently does not provide a way to set the `DUTMaskModeModifier` register on the AIDA2020 TLU, and by default sets this register to zero. This is inconsistent with the default value loaded by the EUDAQ2 producer (0xFF, enabling the modifier for all channels), and in the latter case the register can be directly written in the EUDAQ config.

We have a testbeam/testbench setup (AlVin readout system for ATLAS HGTD/ALTIROC) which we are currently migrating to Constellation, but which relies on being able to raise a DUT busy via the DUTclk signal, and hence needs the DUTMaskModeModifier set for some but not all DUTs. As a result, we need to be able to set this register in the Constellation satellite configuration.

This PR adds the desired functionality as a fourth possible "mode" for a DUT channel - "eudet_with_busy", which enables the `DUTMaskModeModifier` for the given channel by setting the requisite bit (`2 ** channel`). Since this mode only affects the EUDET mode (according to the manual), I believe it is not necessarily to allow this bit to be modifiable for channels that are not in EUDET mode, hence the decision to add it as an extra mode.

Thanks for your time, wishing you a nice start to the week!